### PR TITLE
Update setMetadata--> set_metadata

### DIFF
--- a/cand/canvas.py
+++ b/cand/canvas.py
@@ -858,7 +858,10 @@ class Canvas:
                     page.insertImage(rect, filename=image[0], keep_proportion=False)
             pdf.metadata['creator'] = f"{_idstr}; {pdf.metadata['creator']}"
             pdf.metadata['producer'] = f"{_idstr}; {pdf.metadata['producer']}"
-            pdf.set_metadata(pdf.metadata)
+            try:
+                pdf.setMetadata(pdf.metadata)
+            except AttributeError:
+                pdf.set_metadata(pdf.metadata)
             pdf.save(pdf.name, deflate=True, incremental=True, encryption=mupdf.PDF_ENCRYPT_KEEP)
             pdf.close()
     @pns.accepts(pns.Self, Vector, Point)

--- a/cand/canvas.py
+++ b/cand/canvas.py
@@ -858,7 +858,7 @@ class Canvas:
                     page.insertImage(rect, filename=image[0], keep_proportion=False)
             pdf.metadata['creator'] = f"{_idstr}; {pdf.metadata['creator']}"
             pdf.metadata['producer'] = f"{_idstr}; {pdf.metadata['producer']}"
-            pdf.setMetadata(pdf.metadata)
+            pdf.set_metadata(pdf.metadata)
             pdf.save(pdf.name, deflate=True, incremental=True, encryption=mupdf.PDF_ENCRYPT_KEEP)
             pdf.close()
     @pns.accepts(pns.Self, Vector, Point)


### PR DESCRIPTION
PyMuPDF had some major updates. It seems from their source code that setMetadata should still work as an alias, but I have version 1.21.0 of fitz/pymupdf and I was getting an error at this line. Changing to set_metadata fixes it. 

This could be something to submit as an issue to PyMuPDF rather than fixing here for backwards compatibility with old versions of PyMuPDF, but I didn't dig too deep on the PyMuPDF side. Leaving my fix here in case it makes sense to incorporate it.