### PR TITLE
Feature Added: make text in add_legend customizable

### DIFF
--- a/cand/canvas.py
+++ b/cand/canvas.py
@@ -577,9 +577,10 @@ class Canvas:
         representing the elements to include in the legend.  The first
         element of each tuple should be the name of the legend item,
         the second element should be a dictionary of line properties
-        to be passed to the add_line and add_marker functions.  To
-        withhold drawing a line and only draw markers, set 'linestyle'
-        to the string 'None'.
+        to be passed to the add_line and add_marker functions, with an
+        optional dictionary element in the dictionary, text_params
+        passed to add_text. To withhold drawing a line and only draw
+        markers, set 'linestyle' to the string 'None'.
 
         Additional parameters control formatting.  `line_spacing`
         determines spacing between each line of descriptive text in
@@ -607,9 +608,10 @@ class Canvas:
             # Figure out the vertical position of this element of the legend
             y_offset = -1*line_spacing*i
             # Draw the text
+            params_text = els[i][1].pop('text_params', {})
             self.add_text(els[i][0],
                           top_left + sym_width + padding_sep + y_offset,
-                          horizontalalignment="left", size=fontsize)
+                          horizontalalignment="left", size=fontsize, **params_text)
             pt1 = top_left + y_offset
             pt2 = top_left + sym_width + y_offset
             # Draw the line

--- a/cand/canvas.py
+++ b/cand/canvas.py
@@ -608,19 +608,20 @@ class Canvas:
             # Figure out the vertical position of this element of the legend
             y_offset = -1*line_spacing*i
             # Draw the text
-            params_text = els[i][1].pop('text_params', {})
+            params_dict = els[i][1].copy()
+            params_text = params_dict.pop('text_params', {})
             self.add_text(els[i][0],
                           top_left + sym_width + padding_sep + y_offset,
                           horizontalalignment="left", size=fontsize, **params_text)
             pt1 = top_left + y_offset
             pt2 = top_left + sym_width + y_offset
             # Draw the line
-            params_nomarker = els[i][1].copy()
+            params_nomarker = params_dict.copy()
             params_nomarker['markersize'] = 0
             self.add_line(pt1, pt2, **params_nomarker)
             # Draw the marker.  We need this in an if statement due to
             # a bug in matplotlib.
-            params_noline = els[i][1].copy()
+            params_noline = params_dict.copy()
             params_noline['linestyle'] = 'None'
             self.add_marker(pt1+(pt2-pt1)/2, **params_noline)
     @pns.accepts(pns.Self, pns.List(pns.Or(pns.Tuple(pns.String, pns.String),


### PR DESCRIPTION
As an example, the text color can now be set with the `text_params` field:

```
c = Canvas(5, 5, "cm")
c.add_legend(Point(1,3,"cm" ),[('entry one',{'text_params': {'color': 'orange'}, 'color': 'k'}),('entry two',{'text_params': {'color': 'blue'}, 'color': 'grey'})])
c.show()
```
Resulting in the following legend:
![example.pdf](https://github.com/user-attachments/files/16447162/example.pdf)